### PR TITLE
Ensure RecordNotFound exceptions throw 404

### DIFF
--- a/app/controllers/assets_controller.rb
+++ b/app/controllers/assets_controller.rb
@@ -15,7 +15,6 @@ class AssetsController < Sinatra::Base
   end
 
   error Persistence::RecordNotFound do
-    status 404
     {}.to_json
   end
 

--- a/lib/persistence.rb
+++ b/lib/persistence.rb
@@ -45,7 +45,11 @@ class Persistence
     dataset.where(id: instance.id).delete
   end
 
-  class RecordNotFound < StandardError; end
+  class RecordNotFound < StandardError
+    def http_status
+      404
+    end
+  end
 
   private
 


### PR DESCRIPTION
https://github.com/sinatra/sinatra/blob/master/lib/sinatra/base.rb#L1097

Sinatra overrides the status you may have manually set with whatever the exception status is, or 500 if the exception class doesn't define one.

closes #19 
